### PR TITLE
Completed Wallet Creation Page: Changed reference to Keystore + removed negative margin-top

### DIFF
--- a/frontend/src/pages/Login/CreateAccount.vue
+++ b/frontend/src/pages/Login/CreateAccount.vue
@@ -45,7 +45,6 @@
                   <div class="validate text-danger">
                     <p
                       class="error-message"
-                      style="margin-top: -7px"
                       v-bind:class="{ resolved: confirmed_password }"
                     >
                       password match
@@ -164,8 +163,8 @@ export default {
               name: "create account complete",
               params: {
                 message:
-                  "Congratulations! You have created a KeyStore file for Molly Wallet!",
-                title: "Create a KeyStore File",
+                  "Congratulations! You have created a Private Key file for Molly Wallet!",
+                title: "Create a Private Key File",
                 filePath: filePath,
                 darkMode: this.$route.params.darkMode,
               },


### PR DESCRIPTION
**Old Behaviour:**
References to Keystore:
![image](https://user-images.githubusercontent.com/22587768/97165143-5a942d80-17d7-11eb-952e-01759cfe23ba.png)

Margin on password validation:
![image](https://user-images.githubusercontent.com/22587768/97165165-641d9580-17d7-11eb-8c01-7d564f081f16.png)

New Behaviour:

Reference to Private Key file:
![image](https://user-images.githubusercontent.com/22587768/97165224-7c8db000-17d7-11eb-8d3f-c44879416886.png)

Margin on password validation:
![image](https://user-images.githubusercontent.com/22587768/97165247-844d5480-17d7-11eb-8962-cab3833de132.png)
